### PR TITLE
add check for existing text in text box

### DIFF
--- a/QuickLastMessage/QuickLastMessage.plugin.js
+++ b/QuickLastMessage/QuickLastMessage.plugin.js
@@ -85,6 +85,9 @@ module.exports = (() => {
 					})
 
 					const { textContent } = document.querySelector("div[class*='slateTextArea']").childNodes[0].childNodes[0]
+					if (textContent.trim() != '') {
+						return;
+					}
 					const role = document.activeElement.getAttribute('role')
 
 					if (!textContent.trim().length && message && role === 'textbox') {


### PR DESCRIPTION
I was using the plugin today and while I was trying to edit a longer message I would use the down arrow key to navigate the text. This kept inserting the last message in the middle of my text. It might make sense to make this a configurable option, in case someone wants this behaviour, but here's a quick fix that ignores the down arrow key if the text box isn't empty.