### PR TITLE
Fix stripped indentation

### DIFF
--- a/BetterCodeblocks/BetterCodeblocks.plugin.js
+++ b/BetterCodeblocks/BetterCodeblocks.plugin.js
@@ -123,9 +123,6 @@ module.exports = (() => {
 
 			this.unpatch = Patcher.after(parser.defaultRules.codeBlock, 'react', (_, nodes, output) => {
 				this.inject(nodes, output)
-
-				nodes[0].content = this.dedent(nodes[0].content)
-
 				return output
 			});
 


### PR DESCRIPTION
Fixes #20 

`dedent` caused all indentation to be stripped from code blocks which is incorrect behaviour as it makes nearly all languages unreadable, and makes some languages (i.e. Python) filled with errors.